### PR TITLE
fix(genapi):修复路径分隔符兼容性问题

### DIFF
--- a/cmdgen/genapi/gen.go
+++ b/cmdgen/genapi/gen.go
@@ -130,7 +130,7 @@ func (self *generator) start(filename string) (err error) {
 	gzconsole.Echo.Debugf("开始API文件: %s 内容读取", filename)
 
 	newFilePath := gzutil.Ternary(filepath.IsAbs(filename), trimBeforeKeyword(filename, self.packageName), filename)
-	filePathArr := strings.Split(newFilePath, "/")
+	filePathArr := strings.Split(newFilePath, string(filepath.Separator))
 	switch len(filePathArr) {
 	case 2:
 		self.moduleName = ""

--- a/cmdgen/genapi/genhandler.go
+++ b/cmdgen/genapi/genhandler.go
@@ -121,8 +121,8 @@ func (self *generator) combineHandlerWrite(service *serviceSpec, filename string
 		headerData := map[string]interface{}{
 			"PackageName":       self.handlerPackageName,
 			"HasDto":            hasDto,
-			"DtoPackagePath":    filepath.Join(self.packageName, self.dtoPackagePath),
-			"LogicPackagePath":  filepath.Join(self.packageName, self.logicPackagePath),
+			"DtoPackagePath":    filepath.ToSlash(filepath.Join(self.packageName, self.dtoPackagePath)),
+			"LogicPackagePath":  filepath.ToSlash(filepath.Join(self.packageName, self.logicPackagePath)),
 			"HasRestFul":        hasRestFul,
 			"LogicPackageName":  self.logicPackageName,
 			"LogicStructName":   logicStructName,

--- a/cmdgen/genapi/genlogic.go
+++ b/cmdgen/genapi/genlogic.go
@@ -140,7 +140,7 @@ func (self *generator) writeHeaderTemplate(filename, logicName, packageName stri
 		"LogicName":      logicName,
 		"PackageName":    packageName,
 		"HasDto":         hasDto,
-		"DtoPackagePath": filepath.Join(self.packageName, self.dtoPackagePath),
+		"DtoPackagePath": filepath.ToSlash(filepath.Join(self.packageName, self.dtoPackagePath)),
 	}
 	content, err := executeTemplate(logicHeaderTemplate, data)
 	if err != nil {


### PR DESCRIPTION
- 使用 filepath.Separator 替代硬编码斜杠分割路径
- 统一使用 filepath.ToSlash 处理包路径拼接
- 确保在不同操作系统下路径处理的一致性